### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ provider "intersight" {
 module "terraform-intersight-iks" {
 
   source  = "terraform-cisco-modules/iks/intersight//"
-  version = "2.1.0"
+  version = "2.2"
 
 # Kubernetes Cluster Profile  Adjust the values as needed.
   cluster = {


### PR DESCRIPTION
version in example needed to be updated to at least 2.1.2 to resolve iksVersionName and policyName error:

$ terraform plan
╷
│ Warning: Experimental feature "module_variable_optional_attrs" is active
│ 
│   on .terraform/modules/terraform-intersight-iks/versions.tf line 10, in terraform:
│   10:   experiments = [module_variable_optional_attrs]
│ 
│ Experimental features are subject to breaking changes in future minor or patch releases, based on feedback.
│ 
│ If you have feedback on the design of this feature, please open a GitHub issue to discuss it.
│ 
│ (and 3 more similar warnings elsewhere)
╵
╷
│ Error: Missing required argument
│ 
│   on .terraform/modules/terraform-intersight-iks/main.tf line 116, in module "k8s_version":
│  116: module "k8s_version" {
│ 
│ The argument "iksVersionName" is required, but no definition was found.
╵
╷
│ Error: Missing required argument
│ 
│   on .terraform/modules/terraform-intersight-iks/main.tf line 116, in module "k8s_version":
│  116: module "k8s_version" {
│ 
│ The argument "policyName" is required, but no definition was found.
╵
╷
│ Error: Unsupported argument
│ 
│   on .terraform/modules/terraform-intersight-iks/main.tf line 119, in module "k8s_version":
│  119:   k8s_version      = var.version_policy.version
│ 
│ An argument named "k8s_version" is not expected here.
╵
╷
│ Error: Unsupported argument
│ 
│   on .terraform/modules/terraform-intersight-iks/main.tf line 120, in module "k8s_version":
│  120:   k8s_version_name = var.version_policy.name
│ 
│ An argument named "k8s_version_name" is not expected here.